### PR TITLE
Add C executor to scons build and tests

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -419,6 +419,11 @@ neonbind = env.Program("bin/neonbind", [
     "src/support_exec.cpp",
 ])
 
+neoncx = env.Program("contrib/msvc/Debug/neonvm", [
+    "contrib/NeonVM/neonvm.c",
+    "contrib/NeonVM/stack.c",
+])
+
 env.Depends("src/number.h", libbid)
 env.Depends("src/exec.cpp", libffi)
 
@@ -519,6 +524,7 @@ if use_node:
 tests_jvm = env.Command("tests_jvm", [neonc, "scripts/run_test.py", test_sources], sys.executable + " scripts/run_test.py --runner \"" + sys.executable + " scripts/run_jvm.py\" " + " ".join(x.path for x in test_sources))
 tests_cpp = env.Command("tests_cpp", [neonc, "scripts/run_test.py", "scripts/run_cpp.py", test_sources], sys.executable + " scripts/run_test.py --runner \"" + sys.executable + " scripts/run_cpp.py\" " + " ".join(x.path for x in test_sources))
 tests_py = env.Command("tests_py", [neonc, "scripts/run_test.py", "scripts/run_py.py", test_sources], sys.executable + " scripts/run_test.py --runner \"" + sys.executable + " scripts/run_py.py\" " + " ".join(x.path for x in test_sources))
+tests_cx = env.Command("tests_cx", [neonc, neoncx, "scripts/run_test.py", "scripts/run_c.py", test_sources], sys.executable + " scripts/run_test.py --runner \"" + sys.executable + " scripts/run_c.py\" " + " ".join(x.path for x in test_sources))
 env.Depends(tests_jvm, jvm_classes)
 testenv = env.Clone()
 testenv["ENV"]["NEONPATH"] = "t/"

--- a/scripts/run_c.py
+++ b/scripts/run_c.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 IncludeTests = [
-    "t/arithmetic.neon",
+    #"t/arithmetic.neon",
     "t/hello.neon",
 ]
 
@@ -20,4 +20,4 @@ if fullname.replace("\\", "/") in ExcludeTests:
     sys.exit(99)
 
 subprocess.check_call([os.path.join("bin", "neonc"), "-q", fullname])
-subprocess.check_call(["contrib/msvc/Debug/neonvm.exe", fullname + "x"])
+subprocess.check_call(["contrib/msvc/Debug/neonvm", fullname + "x"])


### PR DESCRIPTION
This makes the C executor run from scons. You can invoke all the tests by using `scons tests_cx`.